### PR TITLE
outputScript address type checking and remove pay to script

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -303,7 +303,7 @@ Script.createOutputScript = function (address, type)
     address = new Address(address);
   }
 
-  if (!type) {
+  if ('undefined' == typeof type) {
     type = 'Pubkey'
   }
   // Standard pay-to-pubkey-hash

--- a/lib/script.js
+++ b/lib/script.js
@@ -115,7 +115,7 @@ Script.prototype.parse = function () {
  * Pubkey:
  *   Paying to a public key directly.
  *   [pubKey] OP_CHECKSIG
- * 
+ *
  * Strange:
  *   Any other script (no template matched).
  */
@@ -136,7 +136,7 @@ Script.prototype.getOutType = function () {
     }
     else {
         return 'Strange';
-    }   
+    }
 }
 
 /**
@@ -179,7 +179,7 @@ Script.prototype.toAddress = function() {
  *
  * Multisig:
  *   Paying to M-of-N public keys.
- * 
+ *
  * Strange:
  *   Any other script (no template matched).
  */
@@ -194,9 +194,9 @@ Script.prototype.getInType = function ()
              Array.isArray(this.chunks[0]) &&
              Array.isArray(this.chunks[1])) {
     return 'Address';
-  } else if (this.chunks[0] == Opcode.map.OP_0 && 
+  } else if (this.chunks[0] == Opcode.map.OP_0 &&
              this.chunks.slice(1).reduce(function(t,chunk,i) {
-                return t && Array.isArray(chunk) 
+                return t && Array.isArray(chunk)
                          && (chunk[0] == 48 || i == this.chunks.length - 1);
              },true)) {
     return 'Multisig';
@@ -299,21 +299,23 @@ Script.prototype.writeBytes = function (data)
 Script.createOutputScript = function (address)
 {
   var script = new Script();
-  address = new Address(address);
+  if ('string' === typeof address) {
+    address = new Address(address);
+  }
   // Standard pay-to-pubkey-hash
-  if (!address.version) {
-      script.writeOp(Opcode.map.OP_DUP);
-      script.writeOp(Opcode.map.OP_HASH160);
-      script.writeBytes(address.hash);
-      script.writeOp(Opcode.map.OP_EQUALVERIFY);
-      script.writeOp(Opcode.map.OP_CHECKSIG);
-  }
+  // if (!address.version) {
+  script.writeOp(Opcode.map.OP_DUP);
+  script.writeOp(Opcode.map.OP_HASH160);
+  script.writeBytes(address.hash);
+  script.writeOp(Opcode.map.OP_EQUALVERIFY);
+  script.writeOp(Opcode.map.OP_CHECKSIG);
+  // }
   // Standard pay-to-script-hash
-  else {
-      script.writeOp(Opcode.map.OP_HASH160);
-      script.writeBytes(address.hash);
-      script.writeOp(Opcode.map.OP_EQUAL);
-  }
+  // else {
+  //     script.writeOp(Opcode.map.OP_HASH160);
+  //     script.writeBytes(address.hash);
+  //     script.writeOp(Opcode.map.OP_EQUAL);
+  // }
   return script;
 };
 
@@ -323,7 +325,7 @@ Script.createOutputScript = function (address)
 
 Script.prototype.extractPubkeys = function() {
     return this.chunks.filter(function(chunk) {
-        return (chunk[0] == 4 && chunk.length == 65 
+        return (chunk[0] == 4 && chunk.length == 65
              || chunk[0]  < 4 && chunk.length == 33)
     });
 }
@@ -336,13 +338,13 @@ Script.createMultiSigOutputScript = function (m, pubkeys)
   var script = new Script();
 
   pubkeys = pubkeys.sort();
-  
+
   script.writeOp(Opcode.map.OP_1 + m - 1);
-  
+
   for (var i = 0; i < pubkeys.length; ++i) {
     script.writeBytes(pubkeys[i]);
   }
-  
+
   script.writeOp(Opcode.map.OP_1 + pubkeys.length - 1);
 
   script.writeOp(Opcode.map.OP_CHECKMULTISIG);

--- a/lib/script.js
+++ b/lib/script.js
@@ -296,26 +296,31 @@ Script.prototype.writeBytes = function (data)
 /**
  * Create an output for an address
  */
-Script.createOutputScript = function (address)
+Script.createOutputScript = function (address, type)
 {
   var script = new Script();
   if ('string' === typeof address) {
     address = new Address(address);
   }
+
+  if (!type) {
+    type = 'Pubkey'
+  }
   // Standard pay-to-pubkey-hash
-  // if (!address.version) {
-  script.writeOp(Opcode.map.OP_DUP);
-  script.writeOp(Opcode.map.OP_HASH160);
-  script.writeBytes(address.hash);
-  script.writeOp(Opcode.map.OP_EQUALVERIFY);
-  script.writeOp(Opcode.map.OP_CHECKSIG);
-  // }
+  if (type === 'Pubkey') {
+    script.writeOp(Opcode.map.OP_DUP);
+    script.writeOp(Opcode.map.OP_HASH160);
+    script.writeBytes(address.hash);
+    script.writeOp(Opcode.map.OP_EQUALVERIFY);
+    script.writeOp(Opcode.map.OP_CHECKSIG);
+  }
   // Standard pay-to-script-hash
-  // else {
-  //     script.writeOp(Opcode.map.OP_HASH160);
-  //     script.writeBytes(address.hash);
-  //     script.writeOp(Opcode.map.OP_EQUAL);
-  // }
+  else if (type === 'P2SH') {
+    script.writeOp(Opcode.map.OP_HASH160);
+    script.writeBytes(address.hash);
+    script.writeOp(Opcode.map.OP_EQUAL);
+  }
+
   return script;
 };
 


### PR DESCRIPTION
My editor automatically removes excess trailing whitespaces so I just realized the diff file is a bit messy

The main change is here: 
https://github.com/cryptocoinjs/btc-script/compare/bugfix-script?expand=1#diff-1635b4f24e4bb7c1006e010d10362130R302
1. type checking for whether address is string and address object
   https://github.com/cryptocoinjs/btc-transaction/blob/master/lib/transaction.js#L130
   You can see on above line that, transaction already creates an address object and feed the address object into the script module
2. remove pay to script hash
   A normal address comes with an address version. I think we need to rethink how to optionally create pay to script hash. We should still default to pay to hash160 transactions.
