### PR TITLE
Supporting standard Script out types

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -3,7 +3,19 @@ var conv = require('convert-hex');
 var Address = require('btc-address');
 var cryptoHash = require('crypto-hashing')
 
+var _defaultNetwork = 'mainnet';
+Address.defaultNetwork = _defaultNetwork;
+
 module.exports = Script;
+Object.defineProperty(Script, 'defaultNetwork', {
+  set: function(val) {
+    _defaultNetwork = val;
+    Address.defaultNetwork = val;
+  },
+  get: function() {
+    return _defaultNetwork;
+  }
+})
 
 function Script(data) {
   if (!data) {
@@ -202,20 +214,21 @@ Script.prototype.getOutType = function() {
          :                             util.sha256ripe160(this.buffer)
 };*/
 
-Script.prototype.toAddress = function() {
+Script.prototype.toAddress = function(network) {
   var outType = this.getOutType();
   if (outType == 'pubkeyhash') {
-    return new Address(this.chunks[2])
+    return new Address(this.chunks[2], 'pubkeyhash', network || Script.defaultNetwork)
   } else if (outType == 'pubkey') {
+    // convert pubkey into a pubkeyhash and do address
     return new Address(cryptoHash.ripemd160(cryptoHash.sha256(this.chunks[0], {
       out: 'bytes'
     }), {
       out: 'bytes'
-    }))
+    }), 'pubkeyhash', network || Script.defaultNetwork)
   } else if (outType == 'scripthash') {
-    return new Address(this.chunks[1], 5)
+    return new Address(this.chunks[1], 'scripthash', network || Script.defaultNetwork)
   } else {
-    return
+    return false
   }
 }
 
@@ -358,18 +371,17 @@ Script.prototype.writeBytes = function(data) {
 /**
  * Create an output for an address
  */
-Script.createOutputScript = function(address, type) {
+Script.createOutputScript = function(address, network) {
   var script = new Script();
   if ('string' === typeof address) {
-    address = new Address(address);
+    // undefined as we have a string address
+    var address = new Address(address, undefined, network || Script.defaultNetwork);
   }
 
-  if ('undefined' == typeof type) {
-    type = 'pubkey'
-  }
+  var type = address.getType(network || Script.defaultNetwork);
 
   // Standard pay-to-pubkey-hash
-  if (type === 'pubkey') {
+  if (type === 'pubkeyhash') {
     script.writeOp(Opcode.map.OP_DUP);
     script.writeOp(Opcode.map.OP_HASH160);
     script.writeBytes(address.hash);
@@ -382,6 +394,9 @@ Script.createOutputScript = function(address, type) {
     script.writeOp(Opcode.map.OP_HASH160);
     script.writeBytes(address.hash);
     script.writeOp(Opcode.map.OP_EQUAL);
+  } else {
+    // address can only be a pubkeyhash address or a scripthash address
+    return false
   }
 
   return script;

--- a/lib/script.js
+++ b/lib/script.js
@@ -1,8 +1,9 @@
 var Opcode = require('btc-opcode');
 var conv = require('convert-hex');
 var Address = require('btc-address');
+var cryptoHash = require('crypto-hashing')
 
-module.exports = Script
+module.exports = Script;
 
 function Script(data) {
   if (!data) {
@@ -18,7 +19,7 @@ function Script(data) {
   }
 
   this.parse();
-};
+}
 
 Script.fromPubKey = function(str) {
   var script = new Script();
@@ -118,30 +119,72 @@ Script.prototype.parse = function() {
  * templates and return a string naming the detected type.
  *
  * Currently supported are:
- * Address:
+ * Pubkeyhash
  *   Paying to a Bitcoin address which is the hash of a pubkey.
  *   OP_DUP OP_HASH160 [pubKeyHash] OP_EQUALVERIFY OP_CHECKSIG
+ *   Example:
  *
  * Pubkey:
  *   Paying to a public key directly.
  *   [pubKey] OP_CHECKSIG
+ *   Example: txid 0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098
+ *
+ * Scripthash (P2SH)
+ *    Paying to an address which is the hash of a script
+ *    OP_HASH160 [Scripthash] OP_EQUAL
+ *    Example:
+ *
+ * Multisig
+ *    Paying to multiple pubkeys and require a number of the signatures
+ *    m [pubkey] [pubkey] [pubkey] n OP_CHECKMULTISIG
+ *    Example:
  *
  * Strange:
  *   Any other script (no template matched).
  */
+
+// Below is the current standard set of out types
+/* const char* GetTxnOutputType(txnouttype t)
+{
+    switch (t)
+    {
+    case TX_NONSTANDARD: return "nonstandard";
+    case TX_PUBKEY: return "pubkey";
+    case TX_PUBKEYHASH: return "pubkeyhash";
+    case TX_SCRIPTHASH: return "scripthash";
+    case TX_MULTISIG: return "multisig";
+    case TX_NULL_DATA: return "nulldata";
+    }
+    return NULL;
+}*/
+
+// todo: analyze escrow transactions
+// https://blockchain.info/tx/09dd94f2c85262173da87a745a459007bb1eed6eeb6bfa238a0cd91a16cf7790?show_adv=true
+// https://github.com/bitcoin/bitcoin/blob/19e5b9d2dfcac4efadba636745485d9660fb1abe/src/script.cpp#L75
+
+// supporting tx_null_data https://github.com/bitcoin/bitcoin/pull/3128
+// https://helloblock.io/mainnet/transactions/ebc9fa1196a59e192352d76c0f6e73167046b9d37b8302b6bb6968dfd279b767
 Script.prototype.getOutType = function() {
-  if (this.chunks[this.chunks.length - 1] == Opcode.map.OP_EQUAL &&
-    this.chunks[0] == Opcode.map.OP_HASH160 &&
-    this.chunks.length == 3) {
-    // Transfer to M-OF-N
-    return 'P2SH';
-  } else if (this.chunks.length == 5 &&
+  if (this.chunks.length == 5 &&
     this.chunks[0] == Opcode.map.OP_DUP &&
     this.chunks[1] == Opcode.map.OP_HASH160 &&
     this.chunks[3] == Opcode.map.OP_EQUALVERIFY &&
     this.chunks[4] == Opcode.map.OP_CHECKSIG) {
     // Transfer to Bitcoin address
+    return 'Pubkeyhash';
+  } else if (this.chunks.length === 2 &&
+    Array.isArray(this.chunks[0]) &&
+    this.chunks[1] === Opcode.map.OP_CHECKSIG) {
+    // [pubkey] OP_CHECKSIG
     return 'Pubkey';
+  } else if (this.chunks[this.chunks.length - 1] == Opcode.map.OP_EQUAL &&
+    this.chunks[0] == Opcode.map.OP_HASH160 &&
+    this.chunks.length == 3) {
+    // Transfer to M-OF-N
+    return 'Scripthash';
+  } else if (this.chunks[this.chunks.length - 1] === Opcode.map.OP_CHECKMULTISIG) {
+    // if script ends with OP_CHECKMULTISIG
+    return 'Multisig'
   } else {
     return 'Strange';
   }
@@ -161,7 +204,19 @@ Script.prototype.getOutType = function() {
 
 Script.prototype.toAddress = function() {
   var outType = this.getOutType();
-  return outType == 'Pubkey' ? new Address(this.chunks[2]) : outType == 'P2SH' ? new Address(this.chunks[1], 5) : new Address(this.chunks[1], 5)
+  if (outType == 'Pubkeyhash') {
+    return new Address(this.chunks[2])
+  } else if (outType == 'Pubkey') {
+    return new Address(cryptoHash.ripemd160(cryptoHash.sha256(this.chunks[0], {
+      out: 'bytes'
+    }), {
+      out: 'bytes'
+    }))
+  } else if (outType == 'Scripthash') {
+    return new Address(this.chunks[1], 5)
+  } else {
+    return
+  }
 }
 
 /**
@@ -312,6 +367,7 @@ Script.createOutputScript = function(address, type) {
   if ('undefined' == typeof type) {
     type = 'Pubkey'
   }
+
   // Standard pay-to-pubkey-hash
   if (type === 'Pubkey') {
     script.writeOp(Opcode.map.OP_DUP);
@@ -320,8 +376,9 @@ Script.createOutputScript = function(address, type) {
     script.writeOp(Opcode.map.OP_EQUALVERIFY);
     script.writeOp(Opcode.map.OP_CHECKSIG);
   }
+
   // Standard pay-to-script-hash
-  else if (type === 'P2SH') {
+  else if (type === 'Scripthash') {
     script.writeOp(Opcode.map.OP_HASH160);
     script.writeBytes(address.hash);
     script.writeOp(Opcode.map.OP_EQUAL);

--- a/lib/script.js
+++ b/lib/script.js
@@ -171,22 +171,22 @@ Script.prototype.getOutType = function() {
     this.chunks[3] == Opcode.map.OP_EQUALVERIFY &&
     this.chunks[4] == Opcode.map.OP_CHECKSIG) {
     // Transfer to Bitcoin address
-    return 'Pubkeyhash';
+    return 'pubkeyhash';
   } else if (this.chunks.length === 2 &&
     Array.isArray(this.chunks[0]) &&
     this.chunks[1] === Opcode.map.OP_CHECKSIG) {
     // [pubkey] OP_CHECKSIG
-    return 'Pubkey';
+    return 'pubkey';
   } else if (this.chunks[this.chunks.length - 1] == Opcode.map.OP_EQUAL &&
     this.chunks[0] == Opcode.map.OP_HASH160 &&
     this.chunks.length == 3) {
     // Transfer to M-OF-N
-    return 'Scripthash';
+    return 'scripthash';
   } else if (this.chunks[this.chunks.length - 1] === Opcode.map.OP_CHECKMULTISIG) {
     // if script ends with OP_CHECKMULTISIG
-    return 'Multisig'
+    return 'multisig'
   } else {
-    return 'Strange';
+    return 'nonstandard';
   }
 }
 
@@ -204,15 +204,15 @@ Script.prototype.getOutType = function() {
 
 Script.prototype.toAddress = function() {
   var outType = this.getOutType();
-  if (outType == 'Pubkeyhash') {
+  if (outType == 'pubkeyhash') {
     return new Address(this.chunks[2])
-  } else if (outType == 'Pubkey') {
+  } else if (outType == 'pubkey') {
     return new Address(cryptoHash.ripemd160(cryptoHash.sha256(this.chunks[0], {
       out: 'bytes'
     }), {
       out: 'bytes'
     }))
-  } else if (outType == 'Scripthash') {
+  } else if (outType == 'scripthash') {
     return new Address(this.chunks[1], 5)
   } else {
     return
@@ -249,18 +249,18 @@ Script.prototype.getInType = function() {
     Array.isArray(this.chunks[0])) {
     // Direct IP to IP transactions only have the signature in their scriptSig.
     // TODO: We could also check that the length of the data is correct.
-    return 'Pubkey';
+    return 'pubkey';
   } else if (this.chunks.length == 2 &&
     Array.isArray(this.chunks[0]) &&
     Array.isArray(this.chunks[1])) {
-    return 'Address';
+    return 'pubkeyhash';
   } else if (this.chunks[0] == Opcode.map.OP_0 &&
     this.chunks.slice(1).reduce(function(t, chunk, i) {
       return t && Array.isArray(chunk) && (chunk[0] == 48 || i == this.chunks.length - 1);
     }, true)) {
-    return 'Multisig';
+    return 'multisig';
   } else {
-    return 'Strange';
+    return 'nonstandard';
   }
 };
 
@@ -279,9 +279,9 @@ Script.prototype.getInType = function() {
  */
 Script.prototype.simpleInPubKey = function() {
   switch (this.getInType()) {
-    case 'Address':
+    case 'pubkeyhash':
       return this.chunks[1];
-    case 'Pubkey':
+    case 'pubkey':
       // TODO: Theoretically, we could recover the pubkey from the sig here.
       //       See https://bitcointalk.org/?topic=6430.0
       throw new Error("Script does not contain pubkey.");
@@ -365,11 +365,11 @@ Script.createOutputScript = function(address, type) {
   }
 
   if ('undefined' == typeof type) {
-    type = 'Pubkey'
+    type = 'pubkey'
   }
 
   // Standard pay-to-pubkey-hash
-  if (type === 'Pubkey') {
+  if (type === 'pubkey') {
     script.writeOp(Opcode.map.OP_DUP);
     script.writeOp(Opcode.map.OP_HASH160);
     script.writeBytes(address.hash);
@@ -378,7 +378,7 @@ Script.createOutputScript = function(address, type) {
   }
 
   // Standard pay-to-script-hash
-  else if (type === 'Scripthash') {
+  else if (type === 'scripthash') {
     script.writeOp(Opcode.map.OP_HASH160);
     script.writeBytes(address.hash);
     script.writeOp(Opcode.map.OP_EQUAL);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "btc-opcode": "0.0.1",
     "convert-hex": "~0.1.0",
-    "btc-address": "~0.2.0"
+    "btc-address": "~0.4.0"
   }
 }

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -39,36 +39,36 @@ describe('Script', function() {
       // https://helloblock.io/mainnet/transactions/dc55d9c6ec03ceccf0db43d29e7d626a8b107f41066e3917f30398bb01dda2b5
       var outHex = '76a9140c79f15f08b0f94a2cba8de036272dee3ecb096188ac'
       var pubkeyhashScript = new Script(outHex)
-      EQ(pubkeyhashScript.getOutType(), 'Pubkeyhash')
+      EQ(pubkeyhashScript.getOutType(), 'pubkeyhash')
     })
 
     it(' > Supports Pubkey', function() {
       // https://helloblock.io/mainnet/transactions/0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098
       var outHex = '410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac'
       var pubkeyScript = new Script(outHex)
-      EQ(pubkeyScript.getOutType(), 'Pubkey')
+      EQ(pubkeyScript.getOutType(), 'pubkey')
     })
 
     it(' > Supports Scripthash', function() {
       // https://helloblock.io/mainnet/transactions/64ebe48e0c9fb8da32160809848a464d303b1e24026d2359597889c3f46f2e21
       var outHex = 'a914f9659d50ec62945a9c8a6c07f117ef63a4f2fcc487'
       var scripthashScript = new Script(outHex)
-      EQ(scripthashScript.getOutType(), 'Scripthash')
+      EQ(scripthashScript.getOutType(), 'scripthash')
     })
 
     it(' > Supports Multisig', function() {
       // https://helloblock.io/mainnet/transactions/09dd94f2c85262173da87a745a459007bb1eed6eeb6bfa238a0cd91a16cf7790
       var outHex = '5121032487c2a32f7c8d57d2a93906a6457afd00697925b0e6e145d89af6d3bca330162102308673d16987eaa010e540901cc6fe3695e758c19f46ce604e174dac315e685a52ae'
       var multisigScript = new Script(outHex)
-      EQ(multisigScript.getOutType(), 'Multisig')
+      EQ(multisigScript.getOutType(), 'multisig')
     })
 
-    it(' > Supports strange (non standard)', function() {
+    it(' > Supports non standard', function() {
       // https://helloblock.io/mainnet/transactions/5e9be7fb36ee49ce84bee4c8ef38ad0efc0608b78dae1c2c99075297ef527890
       // op_return
       var outHex = '6a2606deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474'
       var opreturnScript = new Script(outHex)
-      EQ(opreturnScript.getOutType(), 'Strange')
+      EQ(opreturnScript.getOutType(), 'nonstandard')
     })
   })
 
@@ -77,7 +77,7 @@ describe('Script', function() {
       // https://helloblock.io/mainnet/transactions/0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098
       var outHex = '410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac'
       var pubkeyScript = new Script(outHex)
-      EQ(pubkeyScript.getOutType(), 'Pubkey')
+      EQ(pubkeyScript.getOutType(), 'pubkey')
 
       var addr = pubkeyScript.toAddress()
       EQ(binConv(addr.hash, { in : 'bytes',

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -1,4 +1,5 @@
 var Script = require('../')
+var binConv = require('binstring')
 
 require('terst')
 
@@ -30,6 +31,58 @@ describe('Script', function() {
           }
         }
       }
+    })
+  })
+
+  describe('- Script.getOutType()', function() {
+    it(' > Supports Pubkeyhash', function() {
+      // https://helloblock.io/mainnet/transactions/dc55d9c6ec03ceccf0db43d29e7d626a8b107f41066e3917f30398bb01dda2b5
+      var outHex = '76a9140c79f15f08b0f94a2cba8de036272dee3ecb096188ac'
+      var pubkeyhashScript = new Script(outHex)
+      EQ(pubkeyhashScript.getOutType(), 'Pubkeyhash')
+    })
+
+    it(' > Supports Pubkey', function() {
+      // https://helloblock.io/mainnet/transactions/0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098
+      var outHex = '410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac'
+      var pubkeyScript = new Script(outHex)
+      EQ(pubkeyScript.getOutType(), 'Pubkey')
+    })
+
+    it(' > Supports Scripthash', function() {
+      // https://helloblock.io/mainnet/transactions/64ebe48e0c9fb8da32160809848a464d303b1e24026d2359597889c3f46f2e21
+      var outHex = 'a914f9659d50ec62945a9c8a6c07f117ef63a4f2fcc487'
+      var scripthashScript = new Script(outHex)
+      EQ(scripthashScript.getOutType(), 'Scripthash')
+    })
+
+    it(' > Supports Multisig', function() {
+      // https://helloblock.io/mainnet/transactions/09dd94f2c85262173da87a745a459007bb1eed6eeb6bfa238a0cd91a16cf7790
+      var outHex = '5121032487c2a32f7c8d57d2a93906a6457afd00697925b0e6e145d89af6d3bca330162102308673d16987eaa010e540901cc6fe3695e758c19f46ce604e174dac315e685a52ae'
+      var multisigScript = new Script(outHex)
+      EQ(multisigScript.getOutType(), 'Multisig')
+    })
+
+    it(' > Supports strange (non standard)', function() {
+      // https://helloblock.io/mainnet/transactions/5e9be7fb36ee49ce84bee4c8ef38ad0efc0608b78dae1c2c99075297ef527890
+      // op_return
+      var outHex = '6a2606deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474'
+      var opreturnScript = new Script(outHex)
+      EQ(opreturnScript.getOutType(), 'Strange')
+    })
+  })
+
+  describe('- Script.toAddress()', function() {
+    it(' > returns address for pubkeyScript', function() {
+      // https://helloblock.io/mainnet/transactions/0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098
+      var outHex = '410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac'
+      var pubkeyScript = new Script(outHex)
+      EQ(pubkeyScript.getOutType(), 'Pubkey')
+
+      var addr = pubkeyScript.toAddress()
+      EQ(binConv(addr.hash, { in : 'bytes',
+        out: 'hex'
+      }), '119b098e2e980a229e139a9ed01a469e518e6f26')
     })
   })
 })

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -34,6 +34,28 @@ describe('Script', function() {
     })
   })
 
+  describe(' - Script.createOutputScript()', function() {
+    it(' > Supports pubkeyhash addresses', function() {
+      // hash160 : 0000000000000000000000000000000000000000
+      var pubkeyScript = Script.createOutputScript('1111111111111111111114oLvT2')
+      EQ(pubkeyScript.chunks[2].length, 20)
+      for (var i in pubkeyScript.chunks[2]) {
+        EQ(pubkeyScript.chunks[2][i], 0)
+      }
+      EQ(pubkeyScript.getOutType(), 'pubkeyhash')
+    })
+
+    it(' > Supports scripthash addresses', function() {
+      // hash160 : 0000000000000000000000000000000000000000
+      var scripthashScript = Script.createOutputScript('31h1vYVSYuKP6AhS86fbRdMw9XHieotbST')
+      EQ(scripthashScript.chunks[1].length, 20)
+      for (var i in scripthashScript.chunks[1]) {
+        EQ(scripthashScript.chunks[1][i], 0)
+      }
+      EQ(scripthashScript.getOutType(), 'scripthash')
+    })
+  })
+
   describe('- Script.getOutType()', function() {
     it(' > Supports Pubkeyhash', function() {
       // https://helloblock.io/mainnet/transactions/dc55d9c6ec03ceccf0db43d29e7d626a8b107f41066e3917f30398bb01dda2b5
@@ -83,6 +105,19 @@ describe('Script', function() {
       EQ(binConv(addr.hash, { in : 'bytes',
         out: 'hex'
       }), '119b098e2e980a229e139a9ed01a469e518e6f26')
+    })
+  })
+
+  describe(' - Setting defaultNetwork', function() {
+    it(' > defaults to mainnet and supports testnet', function() {
+      // hash160: 0000000000000000000000000000000000000000
+      Script.defaultNetwork = 'testnet'
+      var pubkeyhashScript = Script.createOutputScript('mfWxJ45yp2SFn7UciZyNpvDKrzbhyfKrY8')
+      EQ(pubkeyhashScript.chunks[2].length, 20)
+      for (var i in pubkeyhashScript.chunks[2]) {
+        EQ(pubkeyhashScript.chunks[2][i], 0)
+      }
+      EQ(pubkeyhashScript.getOutType(), 'pubkeyhash')
     })
   })
 })


### PR DESCRIPTION
In this pull request, I supported all of the standard output script types and align the naming with the satoshi client implementation.

This is the corresponding pull request in Address which also has some of these changes reflected.
