### PR TITLE
Allow to set explicit sorting for public keys in multisig

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -483,10 +483,10 @@ Script.prototype.extractPubkeys = function() {
 /**
  * Create an m-of-n output script
  */
-Script.createMultiSigOutputScript = function(m, pubkeys) {
+Script.createMultiSigOutputScript = function(m, pubkeys, explicitSorting) {
   var script = new Script();
 
-  pubkeys = pubkeys.sort();
+  explicitSorting || (pubkeys = pubkeys.slice().sort());
 
   script.writeOp(Opcode.map.OP_1 + m - 1);
 


### PR DESCRIPTION
Allow to preserve explicit sorting of public keys with `createMultiSigOutputScript`. This is required in cases where you're dealing with ordering that was already pre-determined elsewhere (i.e. when the original script wasn't created with btc-script).

Changes:
- Added an "explicit_sorting" argument to createMultiSigOutputScript
- Prevented public keys argument from being mutated
- Added tests

---

One other thing that I noticed: the way the public keys are currently sorted isn't very intuitive. The `pubkeys` is an array of byte arrays, and when you `sort()` an array of arrays what actually happens is that each element is converted into a string and sorted, meaning that `[[1,2], [3,4], [5,6]].sort()` sorts its as `['1,2', '3,4', '5,6']`. This is both quite unintuitive and different from the way sorting works with other libraries.

I wasn't sure what to do about that - changing that makes sense IMO, but would break backward compatibility. Is that acceptable?
